### PR TITLE
Changes to protean PR

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/prommie_blob.dm
@@ -15,7 +15,6 @@
 	harm_intent_damage = 3
 	melee_damage_lower = 5
 	melee_damage_upper = 5
-	see_in_dark = 10
 	player_msg = "You're a little squisher! Your cuteness level has increased tenfold."
 	heat_damage_per_tick = 20 // Hot and cold are bad, but cold is AS bad for prommies as it is for slimes.
 	cold_damage_per_tick = 20

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -24,7 +24,6 @@
 	melee_damage_lower = 5
 	melee_damage_upper = 5
 	attacktext = list("slashed")
-	see_in_dark = 10
 
 	min_oxy = 0
 	max_oxy = 0

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_blob.dm
@@ -73,6 +73,7 @@
 		humanform = H
 		updatehealth()
 		refactory = locate() in humanform.internal_organs
+		add_verb(src,/mob/living/proc/ventcrawl)
 		add_verb(src,/mob/living/proc/usehardsuit)
 		add_verb(src,/mob/living/simple_mob/protean_blob/proc/nano_partswap)
 		add_verb(src,/mob/living/simple_mob/protean_blob/proc/nano_regenerate)

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_rig.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_rig.dm
@@ -28,6 +28,7 @@
 	//ai_interface_path = "RIGSuit_protean"
 	var/sealed = 0
 	var/assimilated_rig
+	var/can_assimilate_rig = FALSE
 
 /obj/item/rig/protean/relaymove(mob/user, var/direction)
 	if(user.stat || user.stunned)
@@ -491,6 +492,9 @@
 
 //Effectively a round about way of letting a Protean wear other rigs.
 /obj/item/rig/protean/proc/AssimilateRig(mob/user, var/obj/item/rig/R)
+	if(!can_assimilate_rig)
+		to_chat(user, span_warning("You can not place a rig into \the [src]"))
+		return
 	if(!R || assimilated_rig)
 		return
 	if(istype(R, /obj/item/rig/protean))

--- a/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
+++ b/code/modules/mob/living/carbon/human/species/station/protean_vr/protean_species.dm
@@ -40,7 +40,6 @@
 	max_age = 200
 	oxy_mod = 0
 	//radiation_mod = 0	//Can't be assed with fandangling rad protections while blob formed/suited
-	darksight = 10
 	siemens_coefficient = 2
 	brute_mod =        0.8
 	burn_mod =        1.5

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -613,6 +613,11 @@
 			L += D.wrapped
 			if(istype(D.wrapped, /obj/item/storage)) //this should never happen
 				L += get_contents(D.wrapped)
+
+		for(var/obj/item/rig/R in src.contents)	//Check rigsuit storage for items
+			if(R.rig_storage)
+				L += get_contents(R.rig_storage)
+
 		return L
 
 /mob/living/proc/check_contents_for(A)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -12,7 +12,8 @@ var/list/ventcrawl_machinery = list(
 	/obj/machinery/camera,
 	/obj/belly,
 	/obj/screen,
-	/atom/movable/emissive_blocker
+	/atom/movable/emissive_blocker,
+	/obj/item/rig/protean
 	)
 	//VOREStation Edit : added /obj/belly, to this list, CI is complaining about this in his indentation check. Added mob_headset for those with radios so there's no weirdness.
 	//mob/living/simple_mob/borer, //VORESTATION AI TEMPORARY REMOVAL REPLACE BACK IN LIST WHEN RESOLVED //VOREStation Edit
@@ -105,6 +106,31 @@ var/list/ventcrawl_machinery = list(
 			to_chat(src, span_warning("You can't carry \the [A] while ventcrawling!"))
 			return FALSE
 	return TRUE
+
+/mob/living/simple_mob/protean_blob/ventcrawl_carry()
+	for(var/atom/A in contents)
+		if(!is_allowed_vent_crawl_item(A))
+			to_chat(src, span_warning("You can't carry \the [A] while ventcrawling!"))
+			return FALSE
+	if(humanform)
+		for(var/atom/B in humanform.get_contents())
+			if(!is_allowed_vent_crawl_item(B))
+				to_chat(src, span_warning("You can't carry \the [B] while ventcrawling!"))
+				return FALSE
+	return TRUE
+
+/mob/living/simple_mob/protean_blob/is_allowed_vent_crawl_item(var/obj/item/carried_item)
+	if((carried_item in humanform.organs) || (carried_item in humanform.internal_organs))
+		return 1
+	if(istype(carried_item, /obj/item/clothing/under))
+		return 1 //Allow jumpsuits only
+	if(istype(carried_item, /obj/item/rig_module/protean))
+		return 1 //inherent to proteans
+	if(istype(carried_item, /obj/item))
+		var/obj/item/I = carried_item
+		if(I.w_class <= 2)
+			return 1 //Allow them to carry items that fit in pockets
+	return ..()
 
 /mob/living/AltClickOn(var/atom/A)
 	if(is_type_in_list(A,ventcrawl_machinery))

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -121,13 +121,13 @@ var/list/ventcrawl_machinery = list(
 
 /mob/living/simple_mob/protean_blob/is_allowed_vent_crawl_item(var/obj/item/carried_item)
 	if((carried_item in humanform.organs) || (carried_item in humanform.internal_organs))
-		return 1
+		return TRUE
 	if(istype(carried_item, /obj/item/clothing/under))
-		return 1 //Allow jumpsuits only
+		return TRUE //Allow jumpsuits only
 	if(istype(carried_item, /obj/item))
 		var/obj/item/I = carried_item
-		if(I.w_class <= 2)
-			return 1 //Allow them to carry items that fit in pockets
+		if(I.w_class <= ITEMSIZE_SMALL)
+			return TRUE //Allow them to carry items that fit in pockets
 	return ..()
 
 /mob/living/AltClickOn(var/atom/A)

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -124,8 +124,6 @@ var/list/ventcrawl_machinery = list(
 		return 1
 	if(istype(carried_item, /obj/item/clothing/under))
 		return 1 //Allow jumpsuits only
-	if(istype(carried_item, /obj/item/rig_module/protean))
-		return 1 //inherent to proteans
 	if(istype(carried_item, /obj/item))
 		var/obj/item/I = carried_item
 		if(I.w_class <= 2)


### PR DESCRIPTION
Removes dark vision changes.

Removed the ability to assimilate rigs.

Added the ability to vent crawl back, but it now checks their inventory (including inside the rig storage) for any items over pocket-size.