### PR TITLE
Creates a Consume Belly Reagents pref

### DIFF
--- a/code/__defines/_reagents.dm
+++ b/code/__defines/_reagents.dm
@@ -1357,3 +1357,18 @@
 #define REAGENT_ID_SLIMEBONEFIXER "slime_bone_fixer"
 #define REAGENT_SLIMEORGANFIXER "Agent C"
 #define REAGENT_ID_SLIMEORGANFIXER "slime_organ_fixer"
+
+// Vore Belly Options
+
+#define REAGENT_ID_WATER_BELLY "water_liquidbelly"
+#define REAGENT_ID_MILK_BELLY "milk_liquidbelly"
+#define REAGENT_ID_CREAM_BELLY "cream_liquidbelly"
+#define REAGENT_ID_HONEY_BELLY "honey_liquidbelly"
+#define REAGENT_ID_CHERRYJELLY_BELLY "cherry_liquidbelly"
+#define REAGENT_ID_STOMACID_BELLY "stomacid_liquidbelly"
+#define REAGENT_ID_DIETSTOMACID_BELLY "diet_stomacid_liquidbelly"
+#define REAGENT_ID_CLEANER_BELLY "cleaner_liquidbelly"
+#define REAGENT_ID_LUBE_BELLY "lube_liquidbelly"
+#define REAGENT_ID_BIOMASS_BELLY "biomass_liquidbelly"
+#define REAGENT_ID_CONCENTRATEDRADIUM_BELLY "cradium_liquidbelly"
+#define REAGENT_ID_TRICORDRAZINE_BELLY "tricordrazine_liquidbelly"

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -114,7 +114,7 @@
 
 		if(!M.consume_liquid_belly)
 			if(liquid_belly_check())
-				to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!")
+				to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!"))
 				return FALSE
 		var/swallow_whole = FALSE
 		var/obj/belly/belly_target				// These are surprise tools that will help us later

--- a/code/modules/food/food/snacks.dm
+++ b/code/modules/food/food/snacks.dm
@@ -111,6 +111,11 @@
 
 	if(istype(M, /mob/living/carbon))
 		//TODO: replace with standard_feed_mob() call.
+
+		if(!M.consume_liquid_belly)
+			if(liquid_belly_check())
+				to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!")
+				return FALSE
 		var/swallow_whole = FALSE
 		var/obj/belly/belly_target				// These are surprise tools that will help us later
 

--- a/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
+++ b/code/modules/mob/living/simple_mob/subtypes/vore/vore.dm
@@ -36,6 +36,7 @@
 	can_be_drop_pred = client.prefs_vr.can_be_drop_pred
 	throw_vore = client.prefs_vr.throw_vore
 	food_vore = client.prefs_vr.food_vore
+	consume_liquid_belly = client.prefs_vr.consume_liquid_belly
 	allow_spontaneous_tf = client.prefs_vr.allow_spontaneous_tf
 	digest_leave_remains = client.prefs_vr.digest_leave_remains
 	allowmobvore = client.prefs_vr.allowmobvore

--- a/code/modules/reagents/reagent_containers/_reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers/_reagent_containers.dm
@@ -101,6 +101,11 @@
 		to_chat(user, span_notice("\The [src] is empty."))
 		return TRUE
 
+	if(!target.consume_liquid_belly)
+		if(liquid_belly_check())
+			to_chat(user, "[user == target ? "You can't" : "\The [target] can't"] consume that, it contains something produced from a belly!")
+			return FALSE
+
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(!H.check_has_mouth())
@@ -145,3 +150,9 @@
 	var/trans = reagents.trans_to(target, amount_per_transfer_from_this)
 	to_chat(user, span_notice("You transfer [trans] units of the solution to [target]."))
 	return 1
+
+/obj/item/reagent_containers/proc/liquid_belly_check()
+	for(var/datum/reagent/R in reagents.reagent_list)
+		if(R.from_belly)
+			return 1
+	return 0

--- a/code/modules/reagents/reagent_containers/_reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers/_reagent_containers.dm
@@ -154,5 +154,5 @@
 /obj/item/reagent_containers/proc/liquid_belly_check()
 	for(var/datum/reagent/R in reagents.reagent_list)
 		if(R.from_belly)
-			return 1
-	return 0
+			return TRUE
+	return FALSE

--- a/code/modules/reagents/reagent_containers/_reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers/_reagent_containers.dm
@@ -103,7 +103,7 @@
 
 	if(!target.consume_liquid_belly)
 		if(liquid_belly_check())
-			to_chat(user, "[user == target ? "You can't" : "\The [target] can't"] consume that, it contains something produced from a belly!")
+			to_chat(user, span_infoplain("[user == target ? "You can't" : "\The [target] can't"] consume that, it contains something produced from a belly!"))
 			return FALSE
 
 	if(ishuman(target))

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -37,7 +37,7 @@
 		return
 	if(!M.consume_liquid_belly)
 		if(liquid_belly_check())
-			to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] take that, it contains something produced from a belly!")
+			to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] take that, it contains something produced from a belly!"))
 			return FALSE
 
 	var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -35,6 +35,10 @@
 		return
 	if (!istype(M))
 		return
+	if(!M.consume_liquid_belly)
+		if(liquid_belly_check())
+			to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] take that, it contains something produced from a belly!")
+			return FALSE
 
 	var/mob/living/carbon/human/H = M
 	if(istype(H))

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -23,6 +23,10 @@
 		icon_state = "[base_state][rand(1, 4)]" //preset pills only use colour changing or unique icons
 
 /obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
+	if(!M.consume_liquid_belly)
+		if(liquid_belly_check())
+			to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!")
+			return FALSE
 	if(M == user)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -25,7 +25,7 @@
 /obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
 	if(!M.consume_liquid_belly)
 		if(liquid_belly_check())
-			to_chat(user, "[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!")
+			to_chat(user, span_infoplain("[user == M ? "You can't" : "\The [M] can't"] consume that, it contains something produced from a belly!"))
 			return FALSE
 	if(M == user)
 		if(ishuman(M))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -194,6 +194,10 @@
 			var/mob/living/carbon/human/H = target
 			var/obj/item/organ/external/affected //VOREStation Edit - Moved this outside this if
 			if(istype(H))
+				if(!H.consume_liquid_belly)
+					if(liquid_belly_check())
+						to_chat(user, "[user == H ? "You can't" : "\The [H] can't"] take that, it contains something produced from a belly!")
+						return
 				affected = H.get_organ(user.zone_sel.selecting) //VOREStation Edit - See above comment.
 				if(!affected)
 					to_chat(user, span_danger("\The [H] is missing that limb!"))

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -196,7 +196,7 @@
 			if(istype(H))
 				if(!H.consume_liquid_belly)
 					if(liquid_belly_check())
-						to_chat(user, "[user == H ? "You can't" : "\The [H] can't"] take that, it contains something produced from a belly!")
+						to_chat(user, span_infoplain("[user == H ? "You can't" : "\The [H] can't"] take that, it contains something produced from a belly!"))
 						return
 				affected = H.get_organ(user.zone_sel.selecting) //VOREStation Edit - See above comment.
 				if(!affected)

--- a/code/modules/reagents/reagents/_reagents.dm
+++ b/code/modules/reagents/reagents/_reagents.dm
@@ -44,6 +44,8 @@
 	var/glass_desc = "It's a glass of... what, exactly?"
 	var/list/glass_special = null // null equivalent to list()
 
+	var/from_belly = FALSE
+
 /datum/reagent/proc/remove_self(var/amount) // Shortcut
 	if(holder)
 		holder.remove_reagent(id, amount)

--- a/code/modules/reagents/reagents/liquid_belly.dm
+++ b/code/modules/reagents/reagents/liquid_belly.dm
@@ -1,0 +1,49 @@
+// Subtypes of other reagents specifically used in liquid bellies, otherwise identical to the parent
+
+/datum/reagent/water/liquid_belly
+	id = REAGENT_ID_WATER_BELLY
+	from_belly = TRUE
+
+/datum/reagent/drink/milk/liquid_belly
+	id = REAGENT_ID_MILK_BELLY
+	from_belly = TRUE
+
+/datum/reagent/drink/milk/cream/liquid_belly
+	id = REAGENT_ID_CREAM_BELLY
+	from_belly = TRUE
+
+/datum/reagent/nutriment/honey/liquid_belly
+	id = REAGENT_ID_HONEY_BELLY
+	from_belly = TRUE
+
+/datum/reagent/nutriment/cherryjelly/liquid_belly
+	id = REAGENT_ID_CHERRYJELLY_BELLY
+	from_belly = TRUE
+
+/datum/reagent/acid/digestive/liquid_belly
+	id = REAGENT_ID_STOMACID_BELLY
+	from_belly = TRUE
+
+/datum/reagent/acid/diet_digestive/liquid_belly
+	id = REAGENT_ID_DIETSTOMACID_BELLY
+	from_belly = TRUE
+
+/datum/reagent/space_cleaner/liquid_belly
+	id = REAGENT_ID_CLEANER_BELLY
+	from_belly = TRUE
+
+/datum/reagent/lube/liquid_belly
+	id = REAGENT_ID_LUBE_BELLY
+	from_belly = TRUE
+
+/datum/reagent/nutriment/biomass/liquid_belly
+	id = REAGENT_ID_BIOMASS_BELLY
+	from_belly = TRUE
+
+/datum/reagent/radium/concentrated/liquid_belly
+	id = REAGENT_ID_CONCENTRATEDRADIUM_BELLY
+	from_belly = TRUE
+
+/datum/reagent/tricordrazine/liquid_belly
+	id = REAGENT_ID_TRICORDRAZINE_BELLY
+	from_belly = TRUE

--- a/code/modules/vore/eating/belly_obj_liquids.dm
+++ b/code/modules/vore/eating/belly_obj_liquids.dm
@@ -165,7 +165,7 @@
 		if(REAGENT_CLEANER)
 			generated_reagents = list(REAGENT_ID_CLEANER_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_CLEANER
+				reagent_name = "cleaner"
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_CLEANER_BELLY
@@ -197,7 +197,7 @@
 		if(REAGENT_TRICORDRAZINE)
 			generated_reagents = list(REAGENT_ID_TRICORDRAZINE_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_TRICORDRAZINE
+				reagent_name = "tricordrazine"
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_TRICORDRAZINE_BELLY

--- a/code/modules/vore/eating/belly_obj_liquids.dm
+++ b/code/modules/vore/eating/belly_obj_liquids.dm
@@ -107,100 +107,100 @@
 /obj/belly/proc/ReagentSwitch()
 	switch(reagent_chosen)
 		if(REAGENT_WATER)
-			generated_reagents = list(REAGENT_ID_WATER = 1)
+			generated_reagents = list(REAGENT_ID_WATER_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_WATER
+				reagent_name = "water"
 			gen_amount = 1
 			gen_cost = 1
-			reagentid = REAGENT_ID_WATER
+			reagentid = REAGENT_ID_WATER_BELLY
 			reagentcolor = "#0064C877"
 		if(REAGENT_MILK)
-			generated_reagents = list(REAGENT_ID_MILK = 1)
+			generated_reagents = list(REAGENT_ID_MILK_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_MILK
+				reagent_name = "milk"
 			gen_amount = 1
 			gen_cost = 5
-			reagentid = REAGENT_ID_MILK
+			reagentid = REAGENT_ID_MILK_BELLY
 			reagentcolor = "#DFDFDF"
 		if(REAGENT_CREAM)
-			generated_reagents = list(REAGENT_ID_CREAM = 1)
+			generated_reagents = list(REAGENT_ID_CREAM_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_CREAM
+				reagent_name = "cream"
 			gen_amount = 1
 			gen_cost = 5
-			reagentid = REAGENT_ID_CREAM
+			reagentid = REAGENT_ID_CREAM_BELLY
 			reagentcolor = "#DFD7AF"
 		if(REAGENT_HONEY)
-			generated_reagents = list(REAGENT_ID_HONEY = 1)
+			generated_reagents = list(REAGENT_ID_HONEY_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_HONEY
+				reagent_name = "honey"
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_HONEY
+			reagentid = REAGENT_ID_HONEY_BELLY
 			reagentcolor = "#FFFF00"
 		if(REAGENT_CHERRYJELLY)	//Kinda WIP, allows slime like folks something to stuff others with, should make a generic jelly in future
-			generated_reagents = list(REAGENT_ID_CHERRYJELLY = 1)
+			generated_reagents = list(REAGENT_ID_CHERRYJELLY_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
 				reagent_name = "cherry jelly"
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_CHERRYJELLY
+			reagentid = REAGENT_ID_CHERRYJELLY_BELLY
 			reagentcolor = "#801E28"
 		if(REAGENT_STOMACID)
-			generated_reagents = list(REAGENT_ID_STOMACID = 1)
+			generated_reagents = list(REAGENT_ID_STOMACID_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
 				reagent_name = "digestive acid"
 			gen_amount = 1
 			gen_cost = 1
-			reagentid = REAGENT_ID_STOMACID
+			reagentid = REAGENT_ID_STOMACID_BELLY
 			reagentcolor = "#664330"
 		if(REAGENT_DIETSTOMACID)
-			generated_reagents = list(REAGENT_ID_DIETSTOMACID = 1)
+			generated_reagents = list(REAGENT_ID_DIETSTOMACID_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
 				reagent_name = "diluted digestive acid"
 			gen_amount = 1
 			gen_cost = 1
-			reagentid = REAGENT_ID_DIETSTOMACID
+			reagentid = REAGENT_ID_DIETSTOMACID_BELLY
 			reagentcolor = "#664330"
 		if(REAGENT_CLEANER)
-			generated_reagents = list(REAGENT_ID_CLEANER = 1)
+			generated_reagents = list(REAGENT_ID_CLEANER_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
 				reagent_name = REAGENT_CLEANER
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_CLEANER
+			reagentid = REAGENT_ID_CLEANER_BELLY
 			reagentcolor = "#A5F0EE"
 		if(REAGENT_LUBE)
-			generated_reagents = list(REAGENT_ID_LUBE = 1)
+			generated_reagents = list(REAGENT_ID_LUBE_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_LUBE
+				reagent_name = "lube"
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_LUBE
+			reagentid = REAGENT_ID_LUBE_BELLY
 			reagentcolor = "#009CA8"
 		if(REAGENT_BIOMASS)
-			generated_reagents = list(REAGENT_ID_BIOMASS = 1)
+			generated_reagents = list(REAGENT_ID_BIOMASS_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_BIOMASS
+				reagent_name = "biomass"
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_BIOMASS
+			reagentid = REAGENT_ID_BIOMASS_BELLY
 			reagentcolor = "#DF9FBF"
 		if(REAGENT_CONCENTRATEDRADIUM)
-			generated_reagents = list(REAGENT_ID_CONCENTRATEDRADIUM = 1)
+			generated_reagents = list(REAGENT_ID_CONCENTRATEDRADIUM_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
 				reagent_name = "concentrated radium"
 			gen_amount = 1
 			gen_cost = 1
-			reagentid = REAGENT_ID_CONCENTRATEDRADIUM
+			reagentid = REAGENT_ID_CONCENTRATEDRADIUM_BELLY
 			reagentcolor = "#C7C7C7"
 		if(REAGENT_TRICORDRAZINE)
-			generated_reagents = list(REAGENT_ID_TRICORDRAZINE = 1)
+			generated_reagents = list(REAGENT_ID_TRICORDRAZINE_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = REAGENT_ID_TRICORDRAZINE
+				reagent_name = REAGENT_TRICORDRAZINE
 			gen_amount = 1
 			gen_cost = 10
-			reagentid = REAGENT_ID_TRICORDRAZINE
+			reagentid = REAGENT_ID_TRICORDRAZINE_BELLY
 			reagentcolor = "#8040FF"
 			is_beneficial = TRUE
 

--- a/code/modules/vore/eating/belly_obj_liquids.dm
+++ b/code/modules/vore/eating/belly_obj_liquids.dm
@@ -110,7 +110,7 @@
 		our_reagents.Add(lowertext(entry))
 	switch(reagent_chosen)
 		if(REAGENT_WATER)
-			generated_reagents = list(REAGENT_ID_WATER = 1)
+			generated_reagents = list(REAGENT_ID_WATER_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_WATER)
 			gen_amount = 1
@@ -118,7 +118,7 @@
 			reagentid = REAGENT_ID_WATER_BELLY
 			reagentcolor = "#0064C877"
 		if(REAGENT_MILK)
-			generated_reagents = list(REAGENT_ID_MILK = 1)
+			generated_reagents = list(REAGENT_ID_MILK_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_MILK)
 			gen_amount = 1
@@ -126,7 +126,7 @@
 			reagentid = REAGENT_ID_MILK_BELLY
 			reagentcolor = "#DFDFDF"
 		if(REAGENT_CREAM)
-			generated_reagents = list(REAGENT_ID_CREAM = 1)
+			generated_reagents = list(REAGENT_ID_CREAM_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_CREAM)
 			gen_amount = 1
@@ -134,7 +134,7 @@
 			reagentid = REAGENT_ID_CREAM_BELLY
 			reagentcolor = "#DFD7AF"
 		if(REAGENT_HONEY)
-			generated_reagents = list(REAGENT_ID_HONEY = 1)
+			generated_reagents = list(REAGENT_ID_HONEY_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_HONEY)
 			gen_amount = 1
@@ -142,7 +142,7 @@
 			reagentid = REAGENT_ID_HONEY_BELLY
 			reagentcolor = "#FFFF00"
 		if(REAGENT_CHERRYJELLY)	//Kinda WIP, allows slime like folks something to stuff others with, should make a generic jelly in future
-			generated_reagents = list(REAGENT_ID_CHERRYJELLY = 1)
+			generated_reagents = list(REAGENT_ID_CHERRYJELLY_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_CHERRYJELLY)
 			gen_amount = 1
@@ -150,7 +150,7 @@
 			reagentid = REAGENT_ID_CHERRYJELLY_BELLY
 			reagentcolor = "#801E28"
 		if(REAGENT_STOMACID)
-			generated_reagents = list(REAGENT_ID_STOMACID = 1)
+			generated_reagents = list(REAGENT_ID_STOMACID_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_STOMACID)
 			gen_amount = 1
@@ -158,7 +158,7 @@
 			reagentid = REAGENT_ID_STOMACID_BELLY
 			reagentcolor = "#664330"
 		if(REAGENT_DIETSTOMACID)
-			generated_reagents = list(REAGENT_ID_DIETSTOMACID = 1)
+			generated_reagents = list(REAGENT_ID_DIETSTOMACID_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_DIETSTOMACID)
 			gen_amount = 1
@@ -166,7 +166,7 @@
 			reagentid = REAGENT_ID_DIETSTOMACID_BELLY
 			reagentcolor = "#664330"
 		if(REAGENT_CLEANER)
-			generated_reagents = list(REAGENT_ID_CLEANER = 1)
+			generated_reagents = list(REAGENT_ID_CLEANER_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_CLEANER)
 			gen_amount = 1
@@ -174,7 +174,7 @@
 			reagentid = REAGENT_ID_CLEANER_BELLY
 			reagentcolor = "#A5F0EE"
 		if(REAGENT_LUBE)
-			generated_reagents = list(REAGENT_ID_LUBE = 1)
+			generated_reagents = list(REAGENT_ID_LUBE_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_LUBE)
 			gen_amount = 1
@@ -182,7 +182,7 @@
 			reagentid = REAGENT_ID_LUBE_BELLY
 			reagentcolor = "#009CA8"
 		if(REAGENT_BIOMASS)
-			generated_reagents = list(REAGENT_ID_BIOMASS = 1)
+			generated_reagents = list(REAGENT_ID_BIOMASS_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = loowertext(REAGENT_BIOMASS)
 			gen_amount = 1
@@ -190,7 +190,7 @@
 			reagentid = REAGENT_ID_BIOMASS_BELLY
 			reagentcolor = "#DF9FBF"
 		if(REAGENT_CONCENTRATEDRADIUM)
-			generated_reagents = list(REAGENT_ID_CONCENTRATEDRADIUM = 1)
+			generated_reagents = list(REAGENT_ID_CONCENTRATEDRADIUM_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_CONCENTRATEDRADIUM)
 			gen_amount = 1
@@ -198,7 +198,7 @@
 			reagentid = REAGENT_ID_CONCENTRATEDRADIUM_BELLY
 			reagentcolor = "#C7C7C7"
 		if(REAGENT_TRICORDRAZINE)
-			generated_reagents = list(REAGENT_ID_TRICORDRAZINE = 1)
+			generated_reagents = list(REAGENT_ID_TRICORDRAZINE_BELLY = 1)
 			if(reagent_name in our_reagents)
 				reagent_name = lowertext(REAGENT_TRICORDRAZINE)
 			gen_amount = 1

--- a/code/modules/vore/eating/belly_obj_liquids.dm
+++ b/code/modules/vore/eating/belly_obj_liquids.dm
@@ -109,7 +109,7 @@
 		if(REAGENT_WATER)
 			generated_reagents = list(REAGENT_ID_WATER_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "water"
+				reagent_name = REAGENT_ID_WATER
 			gen_amount = 1
 			gen_cost = 1
 			reagentid = REAGENT_ID_WATER_BELLY
@@ -117,7 +117,7 @@
 		if(REAGENT_MILK)
 			generated_reagents = list(REAGENT_ID_MILK_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "milk"
+				reagent_name = REAGENT_ID_MILK
 			gen_amount = 1
 			gen_cost = 5
 			reagentid = REAGENT_ID_MILK_BELLY
@@ -125,7 +125,7 @@
 		if(REAGENT_CREAM)
 			generated_reagents = list(REAGENT_ID_CREAM_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "cream"
+				reagent_name = REAGENT_ID_CREAM
 			gen_amount = 1
 			gen_cost = 5
 			reagentid = REAGENT_ID_CREAM_BELLY
@@ -133,7 +133,7 @@
 		if(REAGENT_HONEY)
 			generated_reagents = list(REAGENT_ID_HONEY_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "honey"
+				reagent_name = REAGENT_ID_HONEY
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_HONEY_BELLY
@@ -165,7 +165,7 @@
 		if(REAGENT_CLEANER)
 			generated_reagents = list(REAGENT_ID_CLEANER_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "cleaner"
+				reagent_name = REAGENT_CLEANER
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_CLEANER_BELLY
@@ -173,7 +173,7 @@
 		if(REAGENT_LUBE)
 			generated_reagents = list(REAGENT_ID_LUBE_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "lube"
+				reagent_name = REAGENT_ID_LUBE
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_LUBE_BELLY
@@ -181,7 +181,7 @@
 		if(REAGENT_BIOMASS)
 			generated_reagents = list(REAGENT_ID_BIOMASS_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "biomass"
+				reagent_name = REAGENT_ID_BIOMASS
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_BIOMASS_BELLY
@@ -197,7 +197,7 @@
 		if(REAGENT_TRICORDRAZINE)
 			generated_reagents = list(REAGENT_ID_TRICORDRAZINE_BELLY = 1)
 			if(capitalize(reagent_name) in reagent_choices)
-				reagent_name = "tricordrazine"
+				reagent_name = REAGENT_ID_TRICORDRAZINE
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_TRICORDRAZINE_BELLY

--- a/code/modules/vore/eating/belly_obj_liquids.dm
+++ b/code/modules/vore/eating/belly_obj_liquids.dm
@@ -184,7 +184,7 @@
 		if(REAGENT_BIOMASS)
 			generated_reagents = list(REAGENT_ID_BIOMASS_BELLY = 1)
 			if(reagent_name in our_reagents)
-				reagent_name = loowertext(REAGENT_BIOMASS)
+				reagent_name = lowertext(REAGENT_BIOMASS)
 			gen_amount = 1
 			gen_cost = 10
 			reagentid = REAGENT_ID_BIOMASS_BELLY

--- a/code/modules/vore/eating/living_vr.dm
+++ b/code/modules/vore/eating/living_vr.dm
@@ -272,6 +272,7 @@
 	P.slip_vore = src.slip_vore
 	P.throw_vore = src.throw_vore
 	P.food_vore = src.food_vore
+	P.consume_liquid_belly = src.consume_liquid_belly
 	P.digest_pain = src.digest_pain
 	P.stumble_vore = src.stumble_vore
 	P.eating_privacy_global = src.eating_privacy_global
@@ -345,6 +346,7 @@
 	throw_vore = P.throw_vore
 	stumble_vore = P.stumble_vore
 	food_vore = P.food_vore
+	consume_liquid_belly = P.consume_liquid_belly
 	digest_pain = P.digest_pain
 	eating_privacy_global = P.eating_privacy_global
 	allow_mimicry = P.allow_mimicry
@@ -1253,6 +1255,7 @@
 	dat += span_bold("Feedable:") + " [feeding ? span_green("Enabled") : span_red("Disabled")]<br>"
 	dat += span_bold("Receiving liquids:") + " [receive_reagents ? span_green("Enabled") : span_red("Disabled")]<br>"
 	dat += span_bold("Giving liquids:") + " [give_reagents ? span_green("Enabled") : span_red("Disabled")]<br>"
+	dat += span_bold("Consuming liquids:") + " [consume_liquid_belly ? span_green("Enabled") : span_red("Disabled")]<br>"
 	dat += span_bold("Late join spawn point belly:") + " [latejoin_vore ? span_green("Enabled") : span_red("Disabled")]<br>"
 	if(latejoin_vore)
 		dat += span_bold("Late join spawn auto accept:") + " [no_latejoin_vore_warning ? span_green("Enabled") : span_red("Disabled")]<br>"

--- a/code/modules/vore/eating/mob_vr.dm
+++ b/code/modules/vore/eating/mob_vr.dm
@@ -18,6 +18,7 @@
 	var/drop_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
 	var/throw_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
 	var/food_vore = TRUE				//Enabled by default since you have to enable drop pred/prey to do this anyway
+	var/consume_liquid_belly = FALSE	//starting off because if someone is into that, they'll toggle it first time they get the error. Otherway around would be more pref breaky.
 	var/digest_pain = TRUE
 	var/can_be_drop_prey = FALSE
 	var/can_be_drop_pred = FALSE

--- a/code/modules/vore/eating/vore_vr.dm
+++ b/code/modules/vore/eating/vore_vr.dm
@@ -61,6 +61,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	var/slip_vore = TRUE
 	var/throw_vore = TRUE
 	var/food_vore = TRUE
+	var/consume_liquid_belly = FALSE //starting off because if someone is into that, they'll toggle it first time they get the error. Otherway around would be more pref breaky.
 
 	var/digest_pain = TRUE
 
@@ -212,6 +213,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	slip_vore = json_from_file["slip_vore"]
 	food_vore = json_from_file["food_vore"]
 	throw_vore = json_from_file["throw_vore"]
+	consume_liquid_belly = json_from_file["consume_liquid_belly"]
 	stumble_vore = json_from_file["stumble_vore"]
 	digest_pain = json_from_file["digest_pain"]
 	nutrition_message_visible = json_from_file["nutrition_message_visible"]
@@ -291,6 +293,8 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 		stumble_vore = TRUE
 	if(isnull(food_vore))
 		food_vore = TRUE
+	if(isnull(consume_liquid_belly))
+		consume_liquid_belly = FALSE
 	if(isnull(digest_pain))
 		digest_pain = TRUE
 	if(isnull(nutrition_message_visible))
@@ -414,7 +418,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 			"throw_vore" 			= throw_vore,
 			"allow_mind_transfer"	= allow_mind_transfer,
 			"phase_vore" 			= phase_vore,
-			"food_vore" 			= food_vore,
+			"consume_liquid_belly" 	= consume_liquid_belly,
 			"digest_pain"			= digest_pain,
 			"nutrition_message_visible"	= nutrition_message_visible,
 			"nutrition_messages"		= nutrition_messages,

--- a/code/modules/vore/eating/vorepanel_vr.dm
+++ b/code/modules/vore/eating/vorepanel_vr.dm
@@ -526,6 +526,7 @@
 		"throw_vore" = host.throw_vore,
 		"phase_vore" = host.phase_vore,
 		"food_vore" = host.food_vore,
+		"consume_liquid_belly" = host.consume_liquid_belly,
 		"digest_pain" = host.digest_pain,
 		"nutrition_message_visible" = host.nutrition_message_visible,
 		"nutrition_messages" = host.nutrition_messages,
@@ -934,6 +935,12 @@
 			host.food_vore = !host.food_vore
 			if(host.client.prefs_vr)
 				host.client.prefs_vr.food_vore = host.food_vore
+			unsaved_changes = TRUE
+			return TRUE
+		if("toggle_consume_liquid_belly")
+			host.consume_liquid_belly = !host.consume_liquid_belly
+			if(host.client.prefs_vr)
+				host.client.prefs_vr.consume_liquid_belly = host.consume_liquid_belly
 			unsaved_changes = TRUE
 			return TRUE
 		if("toggle_digest_pain")

--- a/code/modules/vore/mob_tf.dm
+++ b/code/modules/vore/mob_tf.dm
@@ -128,6 +128,7 @@
 	new_mob.slip_vore = slip_vore
 	new_mob.throw_vore = throw_vore
 	new_mob.food_vore = food_vore
+	new_mob.consume_liquid_belly = consume_liquid_belly
 	new_mob.resizable = resizable
 	new_mob.show_vore_fx = show_vore_fx
 	new_mob.step_mechanics_pref = step_mechanics_pref

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferences.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferences.tsx
@@ -54,6 +54,7 @@ export const VoreUserPreferences = (props: {
     liq_rec,
     liq_giv,
     liq_apply,
+    consume_liquid_belly,
     no_spawnpred_warning,
     no_spawnprey_warning,
     no_spawnpred_warning_time,
@@ -270,6 +271,19 @@ export const VoreUserPreferences = (props: {
       content: {
         enabled: 'Food Vore Enabled',
         disabled: 'Food Vore Disabled',
+      },
+    },
+    toggle_consume_liquid_belly: {
+      action: 'toggle_consume_liquid_belly',
+      test: consume_liquid_belly,
+      tooltip: {
+        main: 'Allows you to consume reagents produced by bellies.',
+        enable: 'Click here to allow consuming belly reagents.',
+        disable: 'Click here to disallow consuming belly reagents.',
+      },
+      content: {
+        enabled: 'Consuming Belly Reagents Enabled',
+        disabled: 'Consuming Belly Reagents Disabled',
       },
     },
     toggle_digest_pain: {

--- a/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferencesTabs/VoreUserPreferencesMechanical.tsx
+++ b/tgui/packages/tgui/interfaces/VorePanel/VoreUserPreferencesTabs/VoreUserPreferencesMechanical.tsx
@@ -114,10 +114,16 @@ export const VoreUserPreferencesMechanical = (props: {
             tooltipPosition="left"
           />
         </Stack.Item>
-        <Stack.Item basis="34%">
+        <Stack.Item basis="32%">
           <VoreUserPreferenceItem
             spec={preferences.allow_mimicry}
             tooltipPosition="right"
+          />
+        </Stack.Item>
+        <Stack.Item basis="32%">
+          <VoreUserPreferenceItem
+            spec={preferences.toggle_consume_liquid_belly}
+            tooltipPosition="top"
           />
         </Stack.Item>
       </Stack>

--- a/tgui/packages/tgui/interfaces/VorePanel/types.ts
+++ b/tgui/packages/tgui/interfaces/VorePanel/types.ts
@@ -269,6 +269,7 @@ export type prefData = {
   liq_rec: BooleanLike;
   liq_giv: BooleanLike;
   liq_apply: BooleanLike;
+  consume_liquid_belly: BooleanLike;
   autotransferable: BooleanLike;
   noisy_full: BooleanLike;
   selective_active: string;
@@ -356,6 +357,7 @@ export type localPrefs = {
   liquid_receive: preferenceData;
   liquid_give: preferenceData;
   liquid_apply: preferenceData;
+  toggle_consume_liquid_belly: preferenceData;
   no_spawnpred_warning: preferenceData;
   no_spawnprey_warning: preferenceData;
   soulcatcher: preferenceData;

--- a/vorestation.dme
+++ b/vorestation.dme
@@ -4048,6 +4048,7 @@
 #include "code\modules\reagents\reagents\drugs.dm"
 #include "code\modules\reagents\reagents\food_drinks.dm"
 #include "code\modules\reagents\reagents\food_drinks_vr.dm"
+#include "code\modules\reagents\reagents\liquid_belly.dm"
 #include "code\modules\reagents\reagents\medicine.dm"
 #include "code\modules\reagents\reagents\medicine_vr.dm"
 #include "code\modules\reagents\reagents\modifiers.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Added a Consume Belly Reagents pref that blocks the consumption of all reagents produced by a belly via reagent containers such as food, drink, beakers, pills, syringes and hyposprays. Seems to work well as intended.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. -->

:cl:
add: Added a Consume Belly Reagents pref that blocks the consumption of all reagents produced by a belly via reagent containers such as food, drink, beakers, pills, syringes and hyposprays.
code: Changed reagents used by liquid bellies to use specific easily identified subtypes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
